### PR TITLE
Add sync and closure based variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFinnvoor%2FFindFaster%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Finnvoor/FindFaster) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFinnvoor%2FFindFaster%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Finnvoor/FindFaster)
 
+Fast asynchronous swift collection search using the [_Boyer–Moore string-search algorithm_](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm).  `fastSearch` can be used with any `BidirectionalCollection` where `Element` is `Equatable` and `Hashable`, and is especially useful for searching large amounts of data or long strings and displaying the results as they come in.
+
+FindFaster is used for find and replace in [HextEdit](https://apps.apple.com/app/apple-store/id1557247094?pt=120542042&ct=github&mt=8), a fast and native macOS hex editor.
+
+## Usage
+### Async 
 ```swift
 import FindFaster
 
 let text = "Lorem ipsum dolor sit amet"
 let search = "or"
 
-for await index in text.fastSearch(for: search) {
+for await index in text.fastSearchStream(for: search) {
     print("Found match at: \(index)")
 }
 
@@ -17,6 +23,32 @@ for await index in text.fastSearch(for: search) {
 //  Found match at: 15
 ```
 
-Fast asynchronous swift collection search using the [_Boyer–Moore string-search algorithm_](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm).  `fastSearch` can be used with any `BidirectionalCollection` where `Element` is `Equatable` and `Hashable`, and is especially useful for searching large amounts of data or long strings and displaying the results as they come in.
+### Sync
+```swift
+import FindFaster
 
-FindFaster is used for find and replace in [HextEdit](https://apps.apple.com/app/apple-store/id1557247094?pt=120542042&ct=github&mt=8), a fast and native macOS hex editor.
+let text = "Lorem ipsum dolor sit amet"
+let search = "or"
+
+let results = text.fastSearch(for: search)
+print("Results: \(results)")
+
+// Prints:
+//  Results: [1, 15]
+```
+
+### Closure-based
+```swift
+import FindFaster
+
+let text = "Lorem ipsum dolor sit amet"
+let search = "or"
+
+text.fastSearch(for: search) { index in
+    print("Found match at: \(index)")
+}
+
+// Prints:
+//  Found match at: 1
+//  Found match at: 15
+```

--- a/Sources/FindFaster/BidirectionalCollection+fastSearch.swift
+++ b/Sources/FindFaster/BidirectionalCollection+fastSearch.swift
@@ -1,79 +1,95 @@
 import Foundation
 
-extension BidirectionalCollection where Element: Equatable, Element: Hashable {
-    public func fastSearch(for element: Self.Element) -> AsyncStream<Index> {
-        singleElementSearch(for: element)
+public extension BidirectionalCollection where Element: Equatable, Element: Hashable {
+    func fastSearchStream(for element: Element) -> AsyncStream<Index> {
+        fastSearchStream(for: [element])
     }
 
-    public func fastSearch(for searchSequence: some Collection<Element>) -> AsyncStream<Index> {
-        switch searchSequence.count {
-        case 0: AsyncStream { $0.finish() }
-        case 1: singleElementSearch(for: searchSequence[searchSequence.startIndex])
-        default: multiElementSearch(for: searchSequence)
-        }
-    }
-
-    private func singleElementSearch(for element: Element) -> AsyncStream<Index> {
+    func fastSearchStream(for searchSequence: some Collection<Element>) -> AsyncStream<Index> {
         AsyncStream { continuation in
             let task = Task {
-                var currentIndex = startIndex
-                while currentIndex < endIndex, !Task.isCancelled {
-                    if self[currentIndex] == element {
-                        continuation.yield(currentIndex)
-                    }
-                    currentIndex = index(after: currentIndex)
+                fastSearch(for: searchSequence) { index in
+                    continuation.yield(index)
                 }
                 continuation.finish()
             }
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
+            continuation.onTermination = { _ in task.cancel() }
         }
+    }
+
+    @discardableResult func fastSearch(
+        for element: Element,
+        onSearchResult: ((Index) -> Void)? = nil
+    ) -> [Index] {
+        fastSearch(for: [element], onSearchResult: onSearchResult)
+    }
+
+    @discardableResult func fastSearch(
+        for searchSequence: some Collection<Element>,
+        onSearchResult: ((Index) -> Void)? = nil
+    ) -> [Index] {
+        switch searchSequence.count {
+        case 0: []
+        case 1: naiveSingleElementSearch(for: searchSequence.first!, onSearchResult: onSearchResult)
+        default: boyerMooreMultiElementSearch(for: searchSequence, onSearchResult: onSearchResult)
+        }
+    }
+}
+
+private extension BidirectionalCollection where Element: Equatable, Element: Hashable {
+    @discardableResult func naiveSingleElementSearch(
+        for element: Element,
+        onSearchResult: ((Index) -> Void)? = nil
+    ) -> [Index] {
+        var indices: [Index] = []
+        var currentIndex = startIndex
+        while currentIndex < endIndex, !Task.isCancelled {
+            if self[currentIndex] == element {
+                indices.append(currentIndex)
+                onSearchResult?(currentIndex)
+            }
+            currentIndex = index(after: currentIndex)
+        }
+        return indices
     }
 
     /// Boyer–Moore algorithm
-    private func multiElementSearch(for searchSequence: some Collection<Element>) -> AsyncStream<Index> {
-        AsyncStream { continuation in
-            guard !searchSequence.isEmpty, searchSequence.count <= count else {
-                continuation.finish()
-                return
-            }
+    @discardableResult func boyerMooreMultiElementSearch(
+        for searchSequence: some Collection<Element>,
+        onSearchResult: ((Index) -> Void)? = nil
+    ) -> [Index] {
+        guard searchSequence.count <= count else { return [] }
 
-            let task = Task {
-                let skipTable: [Element: Int] = searchSequence
-                    .enumerated()
-                    .reduce(into: [:]) { $0[$1.element] = searchSequence.count - $1.offset - 1 }
+        var indices: [Index] = []
+        let skipTable: [Element: Int] = searchSequence
+            .enumerated()
+            .reduce(into: [:]) { $0[$1.element] = searchSequence.count - $1.offset - 1 }
 
-                var currentIndex = index(startIndex, offsetBy: searchSequence.count - 1)
-                while currentIndex < endIndex, !Task.isCancelled {
-                    let skip = skipTable[self[currentIndex]] ?? searchSequence.count
-                    if skip == 0 {
-                        let lowerBound = index(currentIndex, offsetBy: -searchSequence.count + 1)
-                        let upperBound = index(currentIndex, offsetBy: 1)
-                        if self[lowerBound..<upperBound].elementsEqual(searchSequence) {
-                            continuation.yield(lowerBound)
-                        }
-                        guard let nextIndex = index(
-                            currentIndex,
-                            offsetBy: Swift.max(skip, 1),
-                            limitedBy: endIndex
-                        ) else { break }
-                        currentIndex = nextIndex
-                    } else {
-                        guard let nextIndex = index(
-                            currentIndex,
-                            offsetBy: skip,
-                            limitedBy: endIndex
-                        ) else { break }
-                        currentIndex = nextIndex
-                    }
+        var currentIndex = index(startIndex, offsetBy: searchSequence.count - 1)
+        while currentIndex < endIndex, !Task.isCancelled {
+            let skip = skipTable[self[currentIndex]] ?? searchSequence.count
+            if skip == 0 {
+                let lowerBound = index(currentIndex, offsetBy: -searchSequence.count + 1)
+                let upperBound = index(currentIndex, offsetBy: 1)
+                if self[lowerBound..<upperBound].elementsEqual(searchSequence) {
+                    onSearchResult?(lowerBound)
+                    indices.append(lowerBound)
                 }
-                continuation.finish()
-            }
-
-            continuation.onTermination = { _ in
-                task.cancel()
+                guard let nextIndex = index(
+                    currentIndex,
+                    offsetBy: Swift.max(skip, 1),
+                    limitedBy: endIndex
+                ) else { break }
+                currentIndex = nextIndex
+            } else {
+                guard let nextIndex = index(
+                    currentIndex,
+                    offsetBy: skip,
+                    limitedBy: endIndex
+                ) else { break }
+                currentIndex = nextIndex
             }
         }
+        return indices
     }
 }

--- a/Sources/FindFaster/BidirectionalCollection+fastSearch.swift
+++ b/Sources/FindFaster/BidirectionalCollection+fastSearch.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 public extension BidirectionalCollection where Element: Equatable, Element: Hashable {
+    /// Returns an `AsyncStream` delivering indices where the specified value appears in the collection.
+    /// - Parameter element: An element to search for in the collection.
+    /// - Returns: An `AsyncStream` delivering indices where `element` is found.
     func fastSearchStream(for element: Element) -> AsyncStream<Index> {
         fastSearchStream(for: [element])
     }
 
+    /// Returns an `AsyncStream` delivering indices where the specified sequence appears in the collection.
+    /// - Parameter searchSequence: A sequence of elements to search for in the collection.
+    /// - Returns: An `AsyncStream` delivering indices where `searchSequence` is found.
     func fastSearchStream(for searchSequence: some Collection<Element>) -> AsyncStream<Index> {
         AsyncStream { continuation in
             let task = Task {
@@ -17,6 +23,11 @@ public extension BidirectionalCollection where Element: Equatable, Element: Hash
         }
     }
 
+    /// Returns the indices where the specified value appears in the collection.
+    /// - Parameters:
+    ///   - element: An element to search for in the collection.
+    ///   - onSearchResult: An optional closure that is called when a matching index is found.
+    /// - Returns: The indices where `element` is found. If `element` is not found in the collection, returns an empty array.
     @discardableResult func fastSearch(
         for element: Element,
         onSearchResult: ((Index) -> Void)? = nil
@@ -24,6 +35,11 @@ public extension BidirectionalCollection where Element: Equatable, Element: Hash
         fastSearch(for: [element], onSearchResult: onSearchResult)
     }
 
+    /// Returns the indices where the specified sequence appears in the collection.
+    /// - Parameters:
+    ///   - searchSequence: A sequence of elements to search for in the collection.
+    ///   - onSearchResult: An optional closure that is called when a matching index is found.
+    /// - Returns: The indices where `searchSequence` is found. If `searchSequence` is not found in the collection, returns an empty array.
     @discardableResult func fastSearch(
         for searchSequence: some Collection<Element>,
         onSearchResult: ((Index) -> Void)? = nil

--- a/Tests/FindFasterTests/FindFasterTests.swift
+++ b/Tests/FindFasterTests/FindFasterTests.swift
@@ -2,25 +2,56 @@
 import XCTest
 
 final class FindFasterTests: XCTestCase {
-    func testSingleElementSearch() async {
-        let collection = (0..<100)
-        let randomElement = collection.randomElement()!
+    let collection1 = (0..<100)
+    let collection2 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vel lacus in risus finibus semper vel eu magna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Quisque pulvinar gravida varius. Nulla facilisi. Nullam dignissim egestas pellentesque. Morbi nulla sem, porta eu feugiat vitae, faucibus sit amet tellus. Curabitur nunc ligula, scelerisque id rhoncus ac, facilisis quis odio. Pellentesque egestas luctus rutrum. Nam auctor, ligula auctor suscipit elementum, nunc nunc dignissim nibh, eget sollicitudin diam ligula eget ligula. Etiam sed est fermentum, fermentum leo et, vestibulum nisi. Vivamus vestibulum quam sed mattis volutpat. Suspendisse a mi gravida, placerat metus vel, euismod quam. Sed vehicula velit a justo porta eleifend. Sed fringilla auctor nisi elementum lobortis."
 
-        var results: [Int] = []
-        for await index in collection.fastSearch(for: randomElement) {
-            results.append(index)
-        }
-        XCTAssertEqual(results, [randomElement])
+    func testSingleElementSearchSync() {
+        let search = collection1.randomElement()!
+        let results = collection1.fastSearch(for: search)
+        XCTAssertEqual(results, [search])
     }
 
-    func testMultiElementSearch() async {
-        let collection = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vel lacus in risus finibus semper vel eu magna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Quisque pulvinar gravida varius. Nulla facilisi. Nullam dignissim egestas pellentesque. Morbi nulla sem, porta eu feugiat vitae, faucibus sit amet tellus. Curabitur nunc ligula, scelerisque id rhoncus ac, facilisis quis odio. Pellentesque egestas luctus rutrum. Nam auctor, ligula auctor suscipit elementum, nunc nunc dignissim nibh, eget sollicitudin diam ligula eget ligula. Etiam sed est fermentum, fermentum leo et, vestibulum nisi. Vivamus vestibulum quam sed mattis volutpat. Suspendisse a mi gravida, placerat metus vel, euismod quam. Sed vehicula velit a justo porta eleifend. Sed fringilla auctor nisi elementum lobortis."
+    func testMultiElementSearchSync() {
         let search = "et"
+        let results = collection2
+            .fastSearch(for: search)
+            .map { collection2.distance(from: collection2.startIndex, to: $0) }
+        XCTAssertEqual(results, [24, 35, 142, 179, 343, 535, 565, 615, 717])
+    }
 
+    func testSingleElementSearchClosure() {
+        let search = collection1.randomElement()!
         var results: [Int] = []
-        for await index in collection.fastSearch(for: search) {
-            results.append(collection.distance(from: collection.startIndex, to: index))
-            XCTAssertEqual(String(collection[index..<collection.index(index, offsetBy: search.count)]), search)
+        collection1.fastSearch(for: search) { index in
+            results.append(index)
+        }
+        XCTAssertEqual(results, [search])
+    }
+
+    func testMultiElementSearchClosure() {
+        let search = "et"
+        var results: [Int] = []
+        collection2.fastSearch(for: search) { index in
+            results.append(self.collection2.distance(from: self.collection2.startIndex, to: index))
+        }
+        XCTAssertEqual(results, [24, 35, 142, 179, 343, 535, 565, 615, 717])
+    }
+
+    func testSingleElementSearchAsync() async {
+        let search = collection1.randomElement()!
+        var results: [Int] = []
+        for await index in collection1.fastSearchStream(for: search) {
+            results.append(index)
+        }
+        XCTAssertEqual(results, [search])
+    }
+
+    func testMultiElementSearchAsync() async {
+        let search = "et"
+        var results: [Int] = []
+        for await index in collection2.fastSearchStream(for: search) {
+            results.append(collection2.distance(from: collection2.startIndex, to: index))
+            XCTAssertEqual(String(collection2[index..<collection2.index(index, offsetBy: search.count)]), search)
         }
         XCTAssertEqual(results, [24, 35, 142, 179, 343, 535, 565, 615, 717])
     }


### PR DESCRIPTION
closes #1

### Async 
```swift
import FindFaster

let text = "Lorem ipsum dolor sit amet"
let search = "or"

for await index in text.fastSearchStream(for: search) {
    print("Found match at: \(index)")
}

// Prints:
//  Found match at: 1
//  Found match at: 15
```

### Sync
```swift
import FindFaster

let text = "Lorem ipsum dolor sit amet"
let search = "or"

let results = text.fastSearch(for: search)
print("Results: \(results)")

// Prints:
//  Results: [1, 15]
```

### Closure-based
```swift
import FindFaster

let text = "Lorem ipsum dolor sit amet"
let search = "or"

text.fastSearch(for: search) { index in
    print("Found match at: \(index)")
}

// Prints:
//  Found match at: 1
//  Found match at: 15
```